### PR TITLE
hide rotating view and buttons on mobile

### DIFF
--- a/css/events.css
+++ b/css/events.css
@@ -111,6 +111,13 @@
     #rotatingDiv {
         display: none;
     }
+
+    .carousel12 nav {
+        display: none;
+    }
+    .carousel12 nav button {
+        display: none;
+    }
 }
 
 .carousel1 {


### PR DESCRIPTION
hide rotating view and buttons on mobile